### PR TITLE
Add unitary tests

### DIFF
--- a/src/test/java/com/miguel/transaction_api/TransactionApiApplicationTests.java
+++ b/src/test/java/com/miguel/transaction_api/TransactionApiApplicationTests.java
@@ -1,0 +1,13 @@
+package com.miguel.transaction_api;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class TransactionApiApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/src/test/java/com/miguel/transaction_api/controller/TransactionControllerTest.java
+++ b/src/test/java/com/miguel/transaction_api/controller/TransactionControllerTest.java
@@ -1,0 +1,97 @@
+package com.miguel.transaction_api.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.miguel.transaction_api.dto.TransactionRequest;
+import com.miguel.transaction_api.exception.UnprocessableEntity;
+import com.miguel.transaction_api.service.TransactionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class TransactionControllerTest {
+
+    private final String endPoint = "/transacao";
+    @InjectMocks
+    private TransactionController controller;
+    @Mock
+    private TransactionService service;
+    private MockMvc mockMvc;
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final TransactionRequest dto = new TransactionRequest(1D, OffsetDateTime.now().minusYears(1));
+
+    @BeforeEach
+    public void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+        mapper.registerModule(new JavaTimeModule());
+    }
+
+    @Test
+    void shouldRegisterValidTransaction() throws Exception {
+        mockMvc.perform(post(endPoint)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsBytes(dto))
+        ).andExpect(status().isCreated());
+        verify(service, times(1)).addTransaction(any());
+    }
+
+    @Test
+    void shouldReturn422ForNegativeValue() throws Exception {
+        TransactionRequest dtoWithNegativeDTO = new TransactionRequest(-1D, OffsetDateTime.MAX);
+        doThrow(new UnprocessableEntity("Values less than 0 are not allowed")).when(service).addTransaction(dtoWithNegativeDTO);
+        mockMvc.perform(post(endPoint)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsBytes(dtoWithNegativeDTO))
+        ).andExpect(status().isUnprocessableEntity());
+        verify(service, times(1)).addTransaction(dtoWithNegativeDTO);
+    }
+
+    @Test
+    void shouldReturn422ForLaterDate() throws Exception {
+        TransactionRequest dtoWithLaterDate = new TransactionRequest(1D, OffsetDateTime.MAX);
+        doThrow(new UnprocessableEntity("Date and time later than the current date and time")).when(service).addTransaction(dtoWithLaterDate);
+        mockMvc.perform(post(endPoint)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsBytes(dtoWithLaterDate))
+        ).andExpect(status().isUnprocessableEntity());
+        verify(service, times(1)).addTransaction(dtoWithLaterDate);
+    }
+
+    @Test
+    void shouldReturn400ForInvalidRequests() throws Exception {
+        String invalidJson = "{ \"value\": -100, \"dateTime\": \"2024-02-20T23:57:27\" ";
+        mockMvc.perform(post(endPoint)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(invalidJson)
+        ).andExpect(status().isBadRequest());
+    }
+
+
+    @Test
+    void shouldClearingTransactions() throws Exception {
+        mockMvc.perform(delete(endPoint)).andExpect(status().isOk());
+        verify(service, times(1)).clearTransactions();
+    }
+}

--- a/src/test/java/com/miguel/transaction_api/service/TransactionServiceTest.java
+++ b/src/test/java/com/miguel/transaction_api/service/TransactionServiceTest.java
@@ -1,0 +1,64 @@
+package com.miguel.transaction_api.service;
+
+import com.miguel.transaction_api.dto.TransactionRequest;
+import com.miguel.transaction_api.exception.UnprocessableEntity;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TransactionServiceTest {
+
+    @InjectMocks
+    private TransactionService service;
+    private final TransactionRequest dto = new TransactionRequest(1D, OffsetDateTime.now());
+
+    @Test
+    void shouldAddTransaction() {
+        service.addTransaction(dto);
+        List<TransactionRequest> transactions = service.findTransactionsInTime(9999L);
+        assertTrue(transactions.contains(dto));
+    }
+
+    @Test
+    void shouldThrowUnprocessableEntityByDateIsAfter() {
+        assertThrows(UnprocessableEntity.class, () -> service.addTransaction(new TransactionRequest(1D, OffsetDateTime.now().plusSeconds(1))));
+    }
+
+    @Test
+    void shouldThrowUnprocessableEntityByNegativeValues() {
+        assertThrows(UnprocessableEntity.class, () -> service.addTransaction(new TransactionRequest(-1D, OffsetDateTime.MIN)));
+    }
+
+    @Test
+    void shoudExecuteClear() {
+        service.clearTransactions();
+        List<TransactionRequest> transactions = service.findTransactionsInTime(9999999L);
+        assertTrue(transactions.isEmpty());
+    }
+
+    @Test
+    void shouldReturnTransactionsInTime() {
+        Long interval = 3600L;
+        OffsetDateTime now = OffsetDateTime.now();
+        TransactionRequest validTransaction = new TransactionRequest(1D, now.minusMinutes(30));
+        TransactionRequest outdatedTransaction = new TransactionRequest(1D, now.minusHours(2));
+        service.addTransaction(validTransaction);
+        service.addTransaction(outdatedTransaction);
+
+        List<TransactionRequest> result = service.findTransactionsInTime(interval);
+        assertTrue(result.contains(validTransaction));
+        assertFalse(result.contains(outdatedTransaction));
+    }
+}


### PR DESCRIPTION
---

**Add unit tests for Transaction service and controller**

This commit introduces unit tests for both `TransactionService` and `TransactionController`. The tests validate different functionalities:

- **TransactionServiceTest**:
  - Testing adding transactions to the service.
  - Verifying that invalid transactions (negative values and invalid dates) are correctly handled.
  - Ensuring transactions can be cleared successfully.
  - Checking if transactions are returned properly based on time intervals.

- **TransactionControllerTest**:
  - Testing the creation of transactions through the controller.
  - Verifying that negative values trigger a 422 Unprocessable Entity response.
  - Ensuring malformed JSON requests return a 400 Bad Request.
  - Testing the clearing of transactions via the controller's endpoint.

These tests improve the reliability of the `TransactionService` and `TransactionController` by confirming their correct behavior in various scenarios.

---