### PR TITLE
Add unitary tests

### DIFF
--- a/src/test/java/com/miguel/transaction_api/controller/StatisticControllerTest.java
+++ b/src/test/java/com/miguel/transaction_api/controller/StatisticControllerTest.java
@@ -1,0 +1,50 @@
+package com.miguel.transaction_api.controller;
+
+import com.miguel.transaction_api.dto.StatisticsResponse;
+import com.miguel.transaction_api.service.StatisticService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class StatisticControllerTest {
+
+    @InjectMocks
+    private StatisticController controller;
+    @Mock
+    private StatisticService service;
+    private MockMvc mockMvc;
+    private StatisticsResponse response = new StatisticsResponse(1L, 10D, 10D, 10D, 10D);
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Test
+    void getTransactionsInTime() throws Exception {
+        when(service.calculateTransactionStatistics(60L)).thenReturn(response);
+        mockMvc.perform(MockMvcRequestBuilders.get("/estatistica"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.count").value(response.count()))
+                .andExpect(jsonPath("$.sum").value(response.sum()))
+                .andExpect(jsonPath("$.avg").value(response.avg()))
+                .andExpect(jsonPath("$.min").value(response.min()))
+                .andExpect(jsonPath("$.max").value(response.max()));
+
+    }
+}

--- a/src/test/java/com/miguel/transaction_api/service/StatisticServiceTest.java
+++ b/src/test/java/com/miguel/transaction_api/service/StatisticServiceTest.java
@@ -1,0 +1,45 @@
+package com.miguel.transaction_api.service;
+
+import com.miguel.transaction_api.dto.StatisticsResponse;
+import com.miguel.transaction_api.dto.TransactionRequest;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class StatisticServiceTest {
+
+    @InjectMocks
+    private StatisticService statisticService;
+    @Mock
+    private TransactionService transactionService;
+    private final TransactionRequest dto = new TransactionRequest(50D, OffsetDateTime.MIN);
+    private final StatisticsResponse statisticsResponse = new StatisticsResponse(1L, 50D,50D,50D,50D);
+
+    @Test
+    void calculateTransactionStatisticsSuccessfully() {
+        when(transactionService.findTransactionsInTime(60L)).thenReturn(List.of(dto));
+        StatisticsResponse realStatisticsResponse = statisticService.calculateTransactionStatistics(60L);
+
+        verify(transactionService, times(1)).findTransactionsInTime(60L);
+        Assertions.assertThat(realStatisticsResponse).usingRecursiveComparison().isEqualTo(statisticsResponse);
+    }
+
+    @Test
+    void calculateTransactionStatisticsWithEmptyList() {
+        final StatisticsResponse expectedDTO = new StatisticsResponse(0L,0D,0D,0D,0D);
+        when(transactionService.findTransactionsInTime(60L)).thenReturn(List.of());
+        StatisticsResponse realStatisticsResponse = statisticService.calculateTransactionStatistics(60L);
+
+        verify(transactionService, times(1)).findTransactionsInTime(60L);
+        Assertions.assertThat(realStatisticsResponse).usingRecursiveComparison().isEqualTo(expectedDTO);
+    }
+}


### PR DESCRIPTION
### Pull Request Description  

**Title:** ✅ Add Unit Tests for `StatisticController` and `StatisticService`  

**Description:**  
This PR introduces unit tests for the `StatisticController` and `StatisticService`, improving test coverage and ensuring correctness in transaction statistics calculations.  

### 🔍 Changes:  
- **Added `StatisticControllerTest`**  
  - Mocks `StatisticService` to test API endpoint `/estatistica`.  
  - Uses `MockMvc` to verify response status and JSON structure.  

- **Added `StatisticServiceTest`**  
  - Mocks `TransactionService` to validate statistical calculations.  
  - Tests both successful and empty transaction scenarios.  